### PR TITLE
Changed Android Emulator to Simulator.

### DIFF
--- a/doc_source/tutorial-ios-aws-mobile-notes-analytics.rst
+++ b/doc_source/tutorial-ios-aws-mobile-notes-analytics.rst
@@ -16,7 +16,7 @@ Add Analytics to the Notes App
 
 In the :ref:`previous section <tutorial-android-aws-mobile-notes-setup>` of this tutorial, we installed Xcode,
 downloaded a sample note-taking app from GitHub, then compiled and ran
-it in the Android Emulator. This tutorial assumes you have completed the
+it in Simulator. This tutorial assumes you have completed the
 those steps. In this section, we will extend the notes app to
 include application analytics. Application analytics allow us to gather
 demographic information about the application usage.


### PR DESCRIPTION
Simulator is the emulator Xcode uses to run iOS apps on the desktop.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
