### PR TITLE
const name in aws-exports.js is awsmobile not aws_exports

### DIFF
--- a/doc_source/web-getting-started.rst
+++ b/doc_source/web-getting-started.rst
@@ -131,13 +131,13 @@ In :file:`index.js` (or in other code that runs at launch-time), add the followi
 .. code-block:: javascript
 
     import Amplify from 'aws-amplify';
-    import aws_exports from './YOUR-PATH-TO/aws-exports';
+    import awsmobile from './YOUR-PATH-TO/aws-exports';
 
 Then add the following code.
 
 .. code-block:: javascript
 
-    Amplify.configure(aws_exports);
+    Amplify.configure(awsmobile);
 
 
 Run Your App Locally


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
