### PR TITLE
radix parameter is required for parseInt

### DIFF
--- a/doc_source/web-access-apis.rst
+++ b/doc_source/web-access-apis.rst
@@ -192,7 +192,7 @@ The :code:`API` module from AWS Amplify allows you to send requests to your Clou
    .. code:: javascript
 
         async makeGuess() {
-          const guess = parseInt(this.refs.guess.value);
+          const guess = parseInt(this.refs.guess.value, 10);
           const body = { guess }
           const { result } = await API.post('Guesses', '/number', { body });
           this.setState({


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/parseInt

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
