### PR TITLE
Fix small typo to make text render

### DIFF
--- a/doc_source/add-aws-mobile-user-data-storage.rst
+++ b/doc_source/add-aws-mobile-user-data-storage.rst
@@ -288,7 +288,7 @@ Download a File
    Android - Java
     To download a file from an Amazon S3 bucket, use :code:`AWSMobileClient`
     to get the :code:`AWSConfigurationand` :code:`AWSCredentialsProvider` to create the :code:`TransferUtility` object.
-    :code:`AWSMobileClient` expects an activity context for resuming an authenticated session and creating the :cdoe:`AWSCredentialsProvider`.
+    :code:`AWSMobileClient` expects an activity context for resuming an authenticated session and creating the :code:`AWSCredentialsProvider`.
 
     The following example shows using the :code:`TransferUtility` in the context of an Activity.
     If you are creating :code:`TransferUtility` from an application context, you can construct the :code:`AWSCredentialsProvider` and


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Fixed a type from 'cdoe' to 'code' to fix the rendering on this page https://docs.aws.amazon.com/aws-mobile/latest/developerguide/add-aws-mobile-user-data-storage.html.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
