### PR TITLE
Fix message to match other pages, outside of code block

### DIFF
--- a/doc_source/tutorial-ios-aws-mobile-notes-data.rst
+++ b/doc_source/tutorial-ios-aws-mobile-notes-data.rst
@@ -106,7 +106,7 @@ Add NoSQL Data Dependencies
 
       pod install --repo-update
 
-      If you encounter an error message that begins ":code:`[!] Failed to connect to GitHub to update the CocoaPods/Specs . . .`", and your internet connectivity is working, you may need to `update openssl and Ruby <https://stackoverflow.com/questions/38993527/cocoapods-failed-to-connect-to-github-to-update-the-cocoapods-specs-specs-repo/48962041#48962041>`__.Ï
+   If you encounter an error message that begins ":code:`[!] Failed to connect to GitHub to update the CocoaPods/Specs . . .`", and your internet connectivity is working, you may need to `update openssl and Ruby <https://stackoverflow.com/questions/38993527/cocoapods-failed-to-connect-to-github-to-update-the-cocoapods-specs-specs-repo/48962041#48962041>`__.Ï
 
 Implement Mutation Methods
 --------------------------


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
On the other pages in this tutorial, the line changed is not in the preceding code block, but this page was rendering it within it. This PR moves the text outside of the code block. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
