### PR TITLE
docs: add cli command for start

### DIFF
--- a/doc_source/aws-mobile-cli-reference.rst
+++ b/doc_source/aws-mobile-cli-reference.rst
@@ -90,6 +90,10 @@ The current set of commands supported by the :code:`awsmobile CLI` are listed be
 
      - Initializes a new Mobile Hub project, checks for IAM keys, and pulls the aws-exports.js file
 
+   * - :ref:`awsmobile start <projectName> [templateName]`
+     
+     - Starts a new Mobile Hub project using a starter kit: `react` or `react-native`   
+
    * - :ref:`awsmobile configure <aws-mobile-cli-reference-configure>`
 
      - Shows existing keys and allows them to be changed if already set. If keys aren’t set, deep links the user to the IAM console to create keys and then prompts for the access key and secret key. This command helps edit configuration settings for the aws account or the project.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
I noticed, when using [a starter file](https://github.com/aws-samples/aws-mobile-react-sample) that the project was initialized by using a `start` command.  And while the CLI shows this command, the docs don't make reference to it. This PR rectify's that.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
