### PR TITLE
Fixed force unwrapping of nil value for token

### DIFF
--- a/doc_source/tutorial-ios-aws-mobile-notes-data.rst
+++ b/doc_source/tutorial-ios-aws-mobile-notes-data.rst
@@ -200,7 +200,11 @@ Create an AWS AppSync Authentication Context
                 token = task.result!.idToken!.tokenString
                 return nil
              }).waitUntilFinished()
-             return token!
+             if token != nil {
+               return token!
+            } else {
+               return ""
+            }
          }
       }
 


### PR DESCRIPTION
When app was started without an existing authentication token for the user force unwrapping the token of nil would throw. Checking for nil and returning an empty string makes it behave.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
